### PR TITLE
Fix cascading false-positive sensor errors in CGM outlier detection

### DIFF
--- a/backend/app/services/prediction_service.py
+++ b/backend/app/services/prediction_service.py
@@ -51,7 +51,8 @@ N_FEATURES = 6
 GLUCOSE_MIN = 40.0
 GLUCOSE_MAX = 600.0
 PATCH_ERROR_THRESHOLD = 40
-CGM_MAX_CHANGE = 50
+CGM_RAPID_CHANGE = 50    # plausible fast physiological swing (post-meal, post-hypo rebound) — not an error
+CGM_OUTLIER_CHANGE = 80  # actual implausible jump for CGM — treated as a sensor/patch error
 MANUAL_MAX_CHANGE = 80
 AUGMENT_COPIES = 3
 FINETUNE_EPOCHS = 15
@@ -222,16 +223,25 @@ class PredictionService:
     # ==========================================
 
     def _remove_outliers(self, readings: list[dict]) -> list[dict]:
+        """
+        Patch implausible single-reading jumps. Compares each reading against
+        both the previous CLEANED value and the previous RAW value — using
+        only the cleaned value would let one patched reading "freeze" the
+        baseline, making every subsequent *real* reading look like a false
+        cascade of outliers even when they form a perfectly plausible trend
+        (e.g. post-meal or post-hypo rebound).
+        """
         if not readings:
             return readings
         cleaned = [readings[0]]
         for i in range(1, len(readings)):
             current = readings[i]
-            prev = cleaned[-1]
+            prev_cleaned = cleaned[-1]
+            prev_raw = readings[i - 1]
             is_cgm = current.get("source") in ("libreview", "csv_cgm")
-            base_max = CGM_MAX_CHANGE if is_cgm else MANUAL_MAX_CHANGE
+            base_max = CGM_OUTLIER_CHANGE if is_cgm else MANUAL_MAX_CHANGE
 
-            prev_ts = prev.get("measuredAt")
+            prev_ts = prev_cleaned.get("measuredAt")
             curr_ts = current.get("measuredAt")
             if prev_ts and curr_ts:
                 if hasattr(prev_ts, "tzinfo") and prev_ts.tzinfo is None:
@@ -243,12 +253,15 @@ class PredictionService:
             else:
                 max_change = base_max
 
-            if abs(current["value"] - prev["value"]) > max_change:
-                fixed = dict(current)
-                fixed["value"] = prev["value"]
-                cleaned.append(fixed)
-            else:
+            delta_from_cleaned = abs(current["value"] - prev_cleaned["value"])
+            delta_from_raw = abs(current["value"] - prev_raw["value"])
+
+            if delta_from_cleaned <= max_change or delta_from_raw <= max_change:
                 cleaned.append(current)
+            else:
+                fixed = dict(current)
+                fixed["value"] = prev_cleaned["value"]
+                cleaned.append(fixed)
         return cleaned
 
     # ==========================================

--- a/backend/tests/test_outlier_detection.py
+++ b/backend/tests/test_outlier_detection.py
@@ -1,0 +1,71 @@
+"""
+Unit tests for PredictionService._remove_outliers — pure function, no Firestore.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from app.services.prediction_service import prediction_service
+
+BASE_TS = datetime(2026, 7, 3, 18, 0, tzinfo=timezone.utc)
+
+
+def _reading(value: int, minutes_offset: int, source: str = "csv_cgm") -> dict:
+    return {
+        "value": value,
+        "measuredAt": BASE_TS + timedelta(minutes=minutes_offset),
+        "source": source,
+    }
+
+
+class TestRapidButPlausibleTrend:
+    def test_post_hypo_rebound_is_not_flagged_as_outlier(self):
+        """
+        Regression test for a real cascading false-positive: a legitimate
+        rapid rise after a low (68 -> 94 -> 147 -> 183 -> 217, ~15 min apart)
+        used to get patched at 94->147 (delta 53 > old CGM_MAX_CHANGE=50),
+        then every subsequent real reading cascaded into "outlier" too,
+        because each was compared only against the frozen patched value.
+        """
+        readings = [
+            _reading(68, 0),
+            _reading(94, 15),
+            _reading(147, 30),
+            _reading(183, 45),
+            _reading(217, 73),  # slightly larger gap, matches the real report
+        ]
+        cleaned = prediction_service._remove_outliers(readings)
+        assert [r["value"] for r in cleaned] == [68, 94, 147, 183, 217]
+
+
+class TestGenuineOutlierStillCaught:
+    def test_isolated_spike_between_two_stable_readings_is_patched(self):
+        """A single implausible spike surrounded by stable readings should
+        still be treated as a sensor glitch, not accepted."""
+        readings = [
+            _reading(100, 0),
+            _reading(105, 15),
+            _reading(500, 30),  # isolated glitch — no plausible physiological jump this fast
+            _reading(102, 45),
+        ]
+        cleaned = prediction_service._remove_outliers(readings)
+        values = [r["value"] for r in cleaned]
+        assert values[2] != 500, "the isolated 500 spike should have been patched"
+        assert values == [100, 105, 105, 102]
+
+
+class TestCascadePrevention:
+    def test_real_reading_after_a_patched_one_is_not_dragged_down(self):
+        """
+        Once a reading gets patched, the NEXT real reading should be judged
+        against the previous RAW value too, not only the frozen cleaned
+        value — otherwise one glitch drags down every reading after it.
+        """
+        readings = [
+            _reading(100, 0),
+            _reading(300, 15),   # implausible jump — gets patched back to 100
+            _reading(320, 30),   # plausible relative to the RAW 300, even though far from patched 100
+        ]
+        cleaned = prediction_service._remove_outliers(readings)
+        values = [r["value"] for r in cleaned]
+        assert values[1] == 100, "the implausible 300 should still be patched"
+        assert values[2] == 320, "320 is plausible next to the raw 300 and should NOT cascade-patch"


### PR DESCRIPTION
## Summary
- Prevents cascading false-positive sensor errors in CGM outlier detection.
- Distinguishes between plausible rapid CGM changes and actual isolated sensor/patch errors.
- Raises the actual CGM outlier threshold while keeping rapid physiological changes documented separately.
- Adds tests for post-hypo rebound, true isolated outliers, and cascade prevention.

## Test plan
- [x] Verified on Fayez's real CGM sequence: patch_error is now false.
- [x] Added outlier detection tests.
- [x] Existing prediction tests pass, with only pre-existing unrelated failures.