### PR TITLE
Improve prediction and import UI state handling

### DIFF
--- a/frontend/app/(tabs)/glucose-history.tsx
+++ b/frontend/app/(tabs)/glucose-history.tsx
@@ -215,10 +215,7 @@ export default function GlucoseHistoryScreen() {
       if (data.imported_count === 0 && data.skipped_count > 0) {
         Alert.alert(t("importAlreadyTitle"), t("importAlreadyMessage"));
       } else {
-        Alert.alert(
-          t("importSuccessTitle"),
-          `${t("importSuccess", { count: data.imported_count })}\n${t("importSkipped", { count: data.skipped_count })}`,
-        );
+        Alert.alert(t("importSuccessTitle"));
       }
     } catch (e: any) {
       Alert.alert(t("importCSV"), e.message || t("importFailed"));

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -438,7 +438,7 @@ export default function HomeScreen() {
       } else {
         setImportDialog({
           title: t("importSuccessTitle"),
-          message: `${t("importSuccess", { count: data.imported_count })}\n${t("importSkipped", { count: data.skipped_count })}`,
+          message: "",
           isSuccess: true,
         });
       }
@@ -718,7 +718,7 @@ export default function HomeScreen() {
               </>
             ) : (
               <Text style={styles.predictionInsufficient}>
-                {t("predictionUnavailable")}
+                {prediction?.message || t("predictionUnavailable")}
               </Text>
             )}
           </View>


### PR DESCRIPTION
## Summary
- CSV import success dialog no longer shows raw imported/skipped counts —
  just a clean "File Uploaded Successfully" confirmation.
- Applies the cleaner import dialog behavior in both Home and Glucose History.
- Home screen's AI Prediction card now shows the backend's actual
  `prediction.message` (e.g. "Not enough data for prediction...") instead
  of a generic "Prediction unavailable" fallback, so users see *why*
  a prediction isn't available instead of an ambiguous dead-end state.