### PR TITLE
Cap LSTM training window to the most recent 300 readings

### DIFF
--- a/backend/app/services/prediction_service.py
+++ b/backend/app/services/prediction_service.py
@@ -58,6 +58,8 @@ AUGMENT_COPIES = 3
 FINETUNE_EPOCHS = 15
 FINETUNE_LR = 5e-4
 RETRAIN_AFTER_NEW_READINGS = 10  # new readings since last training before a background retrain fires
+TRAINING_WINDOW_READINGS = 300   # cap training data to the most recent N readings, so training time
+                                 # has a fixed ceiling instead of growing forever with lifetime history
 MAX_STALE_HOURS = 24
 PATTERN_DAYS = 30
 PATTERN_HOUR_WINDOW = 1.5   # ±1.5 h circular window
@@ -435,13 +437,19 @@ class PredictionService:
     ) -> tuple[float, float]:
         n = feature_matrix.shape[0]
         scaled = self._normalise(feature_matrix)
+        # Cap what actually gets trained on to the most recent window, so
+        # training cost stays bounded instead of growing forever with a
+        # user's lifetime reading count. `n`/`feature_matrix` (full history)
+        # still drive the retrain-threshold bookkeeping and the forecast
+        # seed below — only the training input itself is windowed.
+        training_matrix = feature_matrix[-TRAINING_WINDOW_READINGS:]
 
         cache = PredictionService._model_cache.get(user_id)
 
         if cache is None:
             # First-ever prediction for this user — nothing to fall back to,
             # train synchronously.
-            model, sigma = self._train_model(feature_matrix)
+            model, sigma = self._train_model(training_matrix)
             with self._cache_lock:
                 PredictionService._model_cache[user_id] = {
                     "model": model, "sigma": sigma,
@@ -457,7 +465,7 @@ class PredictionService:
                         entry["training_in_progress"] = True
                         threading.Thread(
                             target=self._background_retrain,
-                            args=(user_id, feature_matrix, n),
+                            args=(user_id, training_matrix, n),
                             daemon=True,
                         ).start()
                         print(f"[Prediction] Started background retrain for {user_id} "

--- a/backend/tests/test_prediction_cache.py
+++ b/backend/tests/test_prediction_cache.py
@@ -17,6 +17,7 @@ import pytest
 from app.services.prediction_service import (
     prediction_service,
     RETRAIN_AFTER_NEW_READINGS,
+    TRAINING_WINDOW_READINGS,
 )
 
 USER_ID = "cache_test_patient"
@@ -116,3 +117,34 @@ class TestBackgroundRetrain:
         assert entry["sigma"] == new_sigma
         assert entry["trained_n_readings"] == 110
         assert entry["training_in_progress"] is False
+
+
+class TestTrainingWindowCap:
+    def test_training_uses_capped_window_not_full_history(self):
+        """
+        A user with far more readings than TRAINING_WINDOW_READINGS should
+        only have the most recent window fed into training — training cost
+        must not keep growing forever with lifetime history size.
+        """
+        huge_n = TRAINING_WINDOW_READINGS + 500
+        fm = _feature_matrix(huge_n)
+
+        with patch.object(prediction_service, "_train_model") as mock_train:
+            mock_train.return_value = (MagicMock(), 10.0)
+            prediction_service._predict_lstm(fm, USER_ID, hours=1)
+
+        mock_train.assert_called_once()
+        passed_matrix = mock_train.call_args[0][0]
+        assert passed_matrix.shape[0] == TRAINING_WINDOW_READINGS
+
+    def test_full_history_still_used_for_retrain_threshold_bookkeeping(self):
+        """`trained_n_readings` must reflect the TOTAL reading count, not the
+        windowed training size, so the 10-new-readings threshold logic in
+        _predict_lstm still works correctly."""
+        huge_n = TRAINING_WINDOW_READINGS + 500
+        fm = _feature_matrix(huge_n)
+
+        with patch.object(prediction_service, "_train_model", return_value=(MagicMock(), 10.0)):
+            prediction_service._predict_lstm(fm, USER_ID, hours=1)
+
+        assert prediction_service._model_cache[USER_ID]["trained_n_readings"] == huge_n


### PR DESCRIPTION
Training previously used a user's entire lifetime reading history — measured on a real account with 1129 readings, a single training call took ~9.6s warm (up to ~40s+ on a cold process), and that cost only grows as more data accumulates. trained_n_readings bookkeeping (used for the 10-new-readings retrain threshold) still reflects the full count; only the data actually fed into _train_model is windowed, so training cost now has a fixed ceiling regardless of account age.