### PR TITLE
Compute eA1C from a daily-averaged mean, not a flat per-reading mean

### DIFF
--- a/backend/app/services/glucose_service.py
+++ b/backend/app/services/glucose_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone, timedelta
+from datetime import date, datetime, timezone, timedelta
 from firebase_admin import firestore
 from app.models.glucose_reading import GlucoseCreate, GlucoseDocument
 
@@ -376,6 +376,13 @@ class GlucoseService:
         Formula: eA1C = (avg_mg_dL + 46.7) / 28.7  (Nathan et al., 2008)
         Requires >= 14 days of data to be considered reliable.
         Also returns Time in Range breakdown per ADA targets.
+
+        The average feeding the formula is a daily average first, then an
+        average of those daily averages — not a flat average over every
+        reading. A flat average over-weights days with dense CGM sampling
+        (e.g. 96 readings/day) against days with only one manual reading,
+        so importing a CGM CSV could swing the estimate hard purely from
+        sampling density, not an actual change in control.
         """
         since = datetime.now(timezone.utc) - timedelta(days=90)
 
@@ -407,7 +414,13 @@ class GlucoseService:
 
         values = [v for _, v in entries]
         timestamps = [ts for ts, _ in entries]
-        avg = sum(values) / len(values)
+
+        daily_values: dict[date, list[int]] = {}
+        for ts, v in entries:
+            daily_values.setdefault(ts.date(), []).append(v)
+        daily_averages = [sum(vals) / len(vals) for vals in daily_values.values()]
+        avg = sum(daily_averages) / len(daily_averages)
+
         e_a1c = round((avg + 46.7) / 28.7, 1)
 
         days_covered = max(1, (max(timestamps) - min(timestamps)).days + 1)

--- a/backend/tests/test_glucose_service.py
+++ b/backend/tests/test_glucose_service.py
@@ -169,6 +169,47 @@ class TestGetEstimatedA1C:
         assert tir["high"]      == 20.0
         assert tir["very_high"] == 20.0
 
+    def test_a1c_uses_daily_average_not_flat_average(self):
+        """
+        A single day with many dense CGM readings must not outweigh sparse
+        manual-logging days — the average feeding eA1C should be day-weighted
+        (avg of daily avgs), not reading-weighted (flat avg over all rows).
+        """
+        from app.services.glucose_service import glucose_service
+
+        now = datetime.now(timezone.utc)
+        docs = []
+
+        # 14 sparse days, 1 manual reading/day at 100 mg/dL
+        for i in range(1, 15):
+            docs.append(make_doc(100, hours_ago=i * 24))
+
+        # 1 dense CGM day, 96 readings at 300 mg/dL, all within the same day
+        dense_day_start = (now - timedelta(days=20)).replace(
+            hour=0, minute=0, second=0, microsecond=0)
+        for i in range(96):
+            doc = MagicMock()
+            doc.id = f"cgm_{i}"
+            measured = dense_day_start + timedelta(minutes=15 * i)
+            doc.to_dict.return_value = {
+                "userId": PATIENT_ID, "value": 300, "unit": "mg/dL",
+                "measuredAt": measured, "createdAt": measured, "source": "csv_cgm",
+            }
+            docs.append(doc)
+
+        with patch.object(glucose_service, "db") as mock_db:
+            mock_db.collection.return_value.where.return_value.stream.return_value = iter(docs)
+            result = glucose_service.get_estimated_a1c(PATIENT_ID)
+
+        # Day-weighted: (14 days * 100 + 1 day * 300) / 15 days ≈ 113.3
+        # Flat/reading-weighted (old, wrong behavior) would be ≈ 274 instead.
+        assert result["readings_count"] == 14 + 96
+        assert result["average_glucose"] is not None
+        assert result["average_glucose"] < 150, (
+            f"average_glucose={result['average_glucose']} suggests the dense CGM "
+            f"day dominated the average (flat per-reading averaging), not day-weighted"
+        )
+
 
 # ==========================================
 # get_readings / get_latest


### PR DESCRIPTION
A flat average over all readings in the 90-day window over-weights days with dense CGM sampling (e.g. 96 readings/day) against days with only one manual reading — importing a CGM CSV could swing the eA1C estimate hard purely from sampling density, not an actual change in glucose control. Now each day's readings are averaged first, then the per-day averages are averaged, so every day counts equally regardless of how many readings it contains. Time in Range is unaffected (still a straight percentage of readings, matching standard ADA reporting).